### PR TITLE
Set up testing using make on a windows image

### DIFF
--- a/.github/workflows/make-test.yaml
+++ b/.github/workflows/make-test.yaml
@@ -19,3 +19,14 @@ jobs:
       run: make test
     - name: clean
       run: make clean
+      
+  make-test-win:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: build
+      run: make all
+    - name: test-everything
+      run: make test
+    - name: clean
+      run: make clean


### PR DESCRIPTION
According to 
https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md GitHub hosted Windows runners have gcc. Let's see if this works.